### PR TITLE
[EFEKTA-9153] - Convert data to JSON before sending to SQS

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Optional properties:
 * `sqs.endpoint.url`: Override value for the AWS region specific endpoint.
 * `sqs.message.attributes.enabled`: If true, it gets the Kafka Headers and inserts them as SQS MessageAttributes (only string headers are currently supported). Default is false.
 * `sqs.message.attributes.include.list`: The comma separated list of Header names to be included, if empty it includes all the Headers. Default is the empty string.
+* `value.transform.to.json`: If true, it converts the value to a JSON string before sending it to SQS. Default is false. This is useful when the `value.converter` is set to ProtobufConverter or any other non-JSON or String converter.
 
 ### Sample SQS queue policy
 

--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,18 @@
       <artifactId>slf4j-api</artifactId>
       <version>${slf4j.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>5.11.4</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>5.11.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/com/nordstrom/kafka/connect/sqs/SqsConnectorConfig.java
+++ b/src/main/java/com/nordstrom/kafka/connect/sqs/SqsConnectorConfig.java
@@ -15,6 +15,7 @@ abstract public class SqsConnectorConfig extends AbstractConfig {
     private final String topics;
     private final String region;
     private final String endpointUrl;
+    private final Boolean transformToJson;
 
     public SqsConnectorConfig(ConfigDef configDef, Map<?, ?> originals) {
         super(configDef, originals);
@@ -22,6 +23,7 @@ abstract public class SqsConnectorConfig extends AbstractConfig {
         topics = getString(SqsConnectorConfigKeys.TOPICS.getValue());
         region = getString(SqsConnectorConfigKeys.SQS_REGION.getValue());
         endpointUrl = getString(SqsConnectorConfigKeys.SQS_ENDPOINT_URL.getValue());
+        transformToJson = getBoolean(SqsConnectorConfigKeys.VALUE_TRANSFORM_TO_JSON.getValue());
     }
 
     public String getQueueUrl() {
@@ -39,6 +41,8 @@ abstract public class SqsConnectorConfig extends AbstractConfig {
     public String getEndpointUrl()  {
         return endpointUrl;
     }
+
+    public Boolean getTransformToJson() { return transformToJson; }
 
     protected static class CredentialsProviderValidator implements ConfigDef.Validator {
         @Override

--- a/src/main/java/com/nordstrom/kafka/connect/sqs/SqsConnectorConfigKeys.java
+++ b/src/main/java/com/nordstrom/kafka/connect/sqs/SqsConnectorConfigKeys.java
@@ -29,6 +29,7 @@ public enum SqsConnectorConfigKeys {
   SQS_MESSAGE_ATTRIBUTES_ENABLED("sqs.message.attributes.enabled"),
   SQS_MESSAGE_ATTRIBUTES_INCLUDE_LIST("sqs.message.attributes.include.list"),
   SQS_MESSAGE_ATTRIBUTE_PARTITION_KEY("sqs.message.attributes.partition.key"),
+  VALUE_TRANSFORM_TO_JSON("value.transform.to.json"),
 
   // These are not part of the connector configuration proper, but just a convenient
   // place to define the constants.

--- a/src/main/java/com/nordstrom/kafka/connect/sqs/SqsSinkConnectorConfig.java
+++ b/src/main/java/com/nordstrom/kafka/connect/sqs/SqsSinkConnectorConfig.java
@@ -55,7 +55,9 @@ public class SqsSinkConnectorConfig extends SqsConnectorConfig {
       .define(SqsConnectorConfigKeys.CREDENTIALS_PROVIDER_ACCESS_KEY_ID.getValue(), Type.STRING, "", Importance.LOW,
           "AWS Secret Access Key to be used with Config credentials provider.")
       .define(SqsConnectorConfigKeys.CREDENTIALS_PROVIDER_SECRET_ACCESS_KEY.getValue(), Type.PASSWORD, "", Importance.LOW,
-          "AWS Secret Access Key to be used with Config credentials provider");
+          "AWS Secret Access Key to be used with Config credentials provider")
+      .define(SqsConnectorConfigKeys.VALUE_TRANSFORM_TO_JSON.getValue(), Type.BOOLEAN, false, Importance.LOW,
+          "If true, a transformation is applied to the value of the Kafka message to convert it to a JSON string. Default is false.");
 
   public static ConfigDef config() {
     return CONFIG_DEF;

--- a/src/main/java/com/nordstrom/kafka/connect/utils/ObjectMapperProvider.java
+++ b/src/main/java/com/nordstrom/kafka/connect/utils/ObjectMapperProvider.java
@@ -1,0 +1,19 @@
+package com.nordstrom.kafka.connect.utils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import org.apache.kafka.connect.data.Struct;
+
+public class ObjectMapperProvider {
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    static {
+        SimpleModule module = new SimpleModule();
+        module.addSerializer(Struct.class, new StructSerializer());
+        objectMapper.registerModule(module);
+    }
+
+    public static ObjectMapper getObjectMapper() {
+        return objectMapper;
+    }
+}

--- a/src/main/java/com/nordstrom/kafka/connect/utils/StructSerializer.java
+++ b/src/main/java/com/nordstrom/kafka/connect/utils/StructSerializer.java
@@ -1,0 +1,23 @@
+package com.nordstrom.kafka.connect.utils;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import org.apache.kafka.connect.data.Struct;
+
+import java.io.IOException;
+
+public class StructSerializer extends JsonSerializer<Struct> {
+    @Override
+    public void serialize(Struct struct, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+        gen.writeStartObject();
+        struct.schema().fields().forEach(field -> {
+            try {
+                gen.writeObjectField(field.name(), struct.get(field));
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+        gen.writeEndObject();
+    }
+}

--- a/src/main/test/com/nordstrom/kafka/connect/sqs/SqsSinkConnectorTaskTest.java
+++ b/src/main/test/com/nordstrom/kafka/connect/sqs/SqsSinkConnectorTaskTest.java
@@ -1,0 +1,112 @@
+package com.nordstrom.kafka.connect.sqs;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.slf4j.Logger;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+public class SqsSinkConnectorTaskTest {
+
+    @Mock
+    private SqsClient mockClient;
+
+    @Mock
+    private SqsSinkConnectorConfig mockConfig;
+
+    @Mock
+    private Logger mockLogger;
+
+    private SqsSinkConnectorTask task;
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        task = new SqsSinkConnectorTask();
+        task.client = mockClient;
+
+        Map<String, String> configMap = new HashMap<>();
+        configMap.put(SqsConnectorConfigKeys.VALUE_TRANSFORM_TO_JSON.getValue(), "true");
+        configMap.put(SqsConnectorConfigKeys.SQS_QUEUE_URL.getValue(), "http://example.com/queue");
+        configMap.put(SqsConnectorConfigKeys.TOPICS.getValue(), "test-topic");
+        task.config = new SqsSinkConnectorConfig(configMap);
+    }
+
+    @Test
+    public void testPutWithStructValue() throws Exception {
+        Schema schema = SchemaBuilder.struct()
+                .field("field1", Schema.STRING_SCHEMA)
+                .field("field2", Schema.INT32_SCHEMA)
+                .build();
+        Struct struct = new Struct(schema)
+                .put("field1", "test")
+                .put("field2", 123);
+
+        SinkRecord record = new SinkRecord("topic", 0, Schema.STRING_SCHEMA, "key", schema, struct, 0);
+        Collection<SinkRecord> records = Collections.singletonList(record);
+
+        task.put(records);
+
+        ArgumentCaptor<String> bodyCaptor = ArgumentCaptor.forClass(String.class);
+        verify(mockClient).send(anyString(), bodyCaptor.capture(), anyString(), anyString(), any());
+        String body = bodyCaptor.getValue();
+        System.out.println(body);
+        assertEquals("{\"field1\":\"test\",\"field2\":123}", body);
+    }
+
+    @Test
+    public void testPutWithNestedStructValue() throws Exception {
+        Schema nestedSchema = SchemaBuilder.struct()
+                .field("nestedField1", Schema.STRING_SCHEMA)
+                .field("nestedField2", Schema.INT32_SCHEMA)
+                .build();
+
+        Struct nestedStruct = new Struct(nestedSchema)
+                .put("nestedField1", "nestedTest")
+                .put("nestedField2", 456);
+
+        Schema mainSchema = SchemaBuilder.struct()
+                .field("field1", Schema.STRING_SCHEMA)
+                .field("field2", Schema.INT32_SCHEMA)
+                .field("nestedStruct", nestedSchema)
+                .build();
+
+        Struct mainStruct = new Struct(mainSchema)
+                .put("field1", "test")
+                .put("field2", 123)
+                .put("nestedStruct", nestedStruct);
+
+        SinkRecord record = new SinkRecord("topic", 0, Schema.STRING_SCHEMA, "key", mainSchema, mainStruct, 0);
+        Collection<SinkRecord> records = Collections.singletonList(record);
+
+        task.put(records);
+
+        ArgumentCaptor<String> bodyCaptor = ArgumentCaptor.forClass(String.class);
+        verify(mockClient).send(anyString(), bodyCaptor.capture(), anyString(), anyString(), any());
+        String body = bodyCaptor.getValue();
+        System.out.println(body);
+        assertEquals("{\"field1\":\"test\",\"field2\":123,\"nestedStruct\":{\"nestedField1\":\"nestedTest\",\"nestedField2\":456}}", body);
+    }
+
+    @Test
+    public void testPutEmptyRecords() {
+        Collection<SinkRecord> records = Collections.emptyList();
+        task.put(records);
+        verify(mockClient, never()).send(anyString(), anyString(), anyString(), anyString(), anyMap());
+    }
+}
+


### PR DESCRIPTION
This PR aims to add a new config variable `value.transform.to.json` that will transform the received data from Kafka into a JSON before sending it to the SQS. 

This is useful when the `value.converter` is set to `ProtobufConverter` or any other non-string converter as the result coming from Kafka in these cases looks like `struct{field1:value1}` rather than a JSON format.

Using `transforms` doesn't seem enough to convert the `struct` into JSON, so we are enabling this feature in the SQS Sink. 

Potentially, adding new `serializers` for complex types like `Duration` could be useful to represent them as JSON in a better way than the default.