### PR TITLE
[EFEKTA-9153] - Transform Timestamps to datetimes

### DIFF
--- a/src/main/java/com/nordstrom/kafka/connect/sqs/SqsConnectorConfig.java
+++ b/src/main/java/com/nordstrom/kafka/connect/sqs/SqsConnectorConfig.java
@@ -16,6 +16,7 @@ abstract public class SqsConnectorConfig extends AbstractConfig {
     private final String region;
     private final String endpointUrl;
     private final Boolean transformToJson;
+    private final String timestampFormat;
 
     public SqsConnectorConfig(ConfigDef configDef, Map<?, ?> originals) {
         super(configDef, originals);
@@ -24,6 +25,7 @@ abstract public class SqsConnectorConfig extends AbstractConfig {
         region = getString(SqsConnectorConfigKeys.SQS_REGION.getValue());
         endpointUrl = getString(SqsConnectorConfigKeys.SQS_ENDPOINT_URL.getValue());
         transformToJson = getBoolean(SqsConnectorConfigKeys.VALUE_TRANSFORM_TO_JSON.getValue());
+        timestampFormat = getString(SqsConnectorConfigKeys.VALUE_TRANSFORM_TIMESTAMP_FORMAT.getValue());
     }
 
     public String getQueueUrl() {
@@ -43,6 +45,8 @@ abstract public class SqsConnectorConfig extends AbstractConfig {
     }
 
     public Boolean getTransformToJson() { return transformToJson; }
+
+    public String getTimestampFormat() { return timestampFormat; }
 
     protected static class CredentialsProviderValidator implements ConfigDef.Validator {
         @Override

--- a/src/main/java/com/nordstrom/kafka/connect/sqs/SqsConnectorConfigKeys.java
+++ b/src/main/java/com/nordstrom/kafka/connect/sqs/SqsConnectorConfigKeys.java
@@ -30,6 +30,7 @@ public enum SqsConnectorConfigKeys {
   SQS_MESSAGE_ATTRIBUTES_INCLUDE_LIST("sqs.message.attributes.include.list"),
   SQS_MESSAGE_ATTRIBUTE_PARTITION_KEY("sqs.message.attributes.partition.key"),
   VALUE_TRANSFORM_TO_JSON("value.transform.to.json"),
+  VALUE_TRANSFORM_TIMESTAMP_FORMAT("value.transform.timestamp.format"),
 
   // These are not part of the connector configuration proper, but just a convenient
   // place to define the constants.

--- a/src/main/java/com/nordstrom/kafka/connect/sqs/SqsSinkConnectorConfig.java
+++ b/src/main/java/com/nordstrom/kafka/connect/sqs/SqsSinkConnectorConfig.java
@@ -57,7 +57,9 @@ public class SqsSinkConnectorConfig extends SqsConnectorConfig {
       .define(SqsConnectorConfigKeys.CREDENTIALS_PROVIDER_SECRET_ACCESS_KEY.getValue(), Type.PASSWORD, "", Importance.LOW,
           "AWS Secret Access Key to be used with Config credentials provider")
       .define(SqsConnectorConfigKeys.VALUE_TRANSFORM_TO_JSON.getValue(), Type.BOOLEAN, false, Importance.LOW,
-          "If true, a transformation is applied to the value of the Kafka message to convert it to a JSON string. Default is false.");
+          "If true, a transformation is applied to the value of the Kafka message to convert it to a JSON string. Default is false.")
+      .define(SqsConnectorConfigKeys.VALUE_TRANSFORM_TIMESTAMP_FORMAT.getValue(), Type.STRING, "yyyy-MM-dd'T'HH:mm:ss'Z'", Importance.LOW,
+          String.format("When %s is true, Timestamps are transformed into a string using this format. Default is yyyy-MM-dd'T'HH:mm:ss'Z'.", SqsConnectorConfigKeys.VALUE_TRANSFORM_TO_JSON.getValue()));
 
   public static ConfigDef config() {
     return CONFIG_DEF;

--- a/src/main/java/com/nordstrom/kafka/connect/sqs/SqsSinkConnectorTask.java
+++ b/src/main/java/com/nordstrom/kafka/connect/sqs/SqsSinkConnectorTask.java
@@ -44,7 +44,7 @@ public class SqsSinkConnectorTask extends SinkTask {
 
   // Used to serialize Struct objects to JSON
   // This is needed when the value.converter is set to Protobuf, Avro or any other non-String format
-  private final ObjectMapper objectMapper = ObjectMapperProvider.getObjectMapper();
+  ObjectMapper objectMapper;
 
 
   /*
@@ -69,6 +69,7 @@ public class SqsSinkConnectorTask extends SinkTask {
 
     config = new SqsSinkConnectorConfig( props ) ;
     client = new SqsClient(config) ;
+    objectMapper = ObjectMapperProvider.getObjectMapper(config.getTimestampFormat());
 
     log.info( "task.start:OK, sqs.queue.url={}, topics={}", config.getQueueUrl(), config.getTopics() ) ;
   }

--- a/src/main/java/com/nordstrom/kafka/connect/utils/ObjectMapperProvider.java
+++ b/src/main/java/com/nordstrom/kafka/connect/utils/ObjectMapperProvider.java
@@ -7,13 +7,10 @@ import org.apache.kafka.connect.data.Struct;
 public class ObjectMapperProvider {
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
-    static {
+    public static ObjectMapper getObjectMapper(String timestampPattern) {
         SimpleModule module = new SimpleModule();
-        module.addSerializer(Struct.class, new StructSerializer());
+        module.addSerializer(Struct.class, new StructSerializer(timestampPattern));
         objectMapper.registerModule(module);
-    }
-
-    public static ObjectMapper getObjectMapper() {
         return objectMapper;
     }
 }

--- a/src/main/java/com/nordstrom/kafka/connect/utils/StructSerializer.java
+++ b/src/main/java/com/nordstrom/kafka/connect/utils/StructSerializer.java
@@ -4,16 +4,32 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.data.Timestamp;
 
 import java.io.IOException;
+import java.text.SimpleDateFormat;
 
 public class StructSerializer extends JsonSerializer<Struct> {
+
+    private static String timestampPattern;
+    private static SimpleDateFormat dateFormat;
+
+    public StructSerializer(String timestampPattern) {
+        StructSerializer.timestampPattern = timestampPattern;
+        dateFormat = new SimpleDateFormat(timestampPattern);
+    }
+
     @Override
     public void serialize(Struct struct, JsonGenerator gen, SerializerProvider serializers) throws IOException {
         gen.writeStartObject();
         struct.schema().fields().forEach(field -> {
             try {
-                gen.writeObjectField(field.name(), struct.get(field));
+                Object value = struct.get(field);
+                // Transform timestamp to defined format
+                if (timestampPattern != null && field.schema().name() != null && field.schema().name().equals(Timestamp.LOGICAL_NAME)) {
+                    value = dateFormat.format(value);
+                }
+                gen.writeObjectField(field.name(), value);
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }


### PR DESCRIPTION
This PR aims to enable a new config (`value.transform.timestamp.format`) that allow to transform `timestamps` into `datetime` in the defined pattern. 
It uses `yyyy-MM-dd'T'HH:mm:ss'Z'` by default.

This is only enabled when `value.transform.to.json` is enabled.