### PR TITLE
 Throw exception on parsing errors

### DIFF
--- a/src/main/java/com/nordstrom/kafka/connect/sqs/SqsSinkConnectorTask.java
+++ b/src/main/java/com/nordstrom/kafka/connect/sqs/SqsSinkConnectorTask.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map ;
 
 import com.amazonaws.services.sqs.model.MessageAttributeValue;
+import com.nordstrom.kafka.connect.utils.ParseException;
 import org.apache.kafka.common.errors.RetriableException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nordstrom.kafka.connect.utils.ObjectMapperProvider;
@@ -104,6 +105,7 @@ public class SqsSinkConnectorTask extends SinkTask {
             body = objectMapper.writeValueAsString(record.value());
           } catch (Exception e) {
             log.error("Failed to convert record value to JSON", e);
+            throw new ParseException(e.getMessage(), e.getCause());
           }
         }
         else {

--- a/src/main/java/com/nordstrom/kafka/connect/utils/ParseException.java
+++ b/src/main/java/com/nordstrom/kafka/connect/utils/ParseException.java
@@ -1,0 +1,9 @@
+package com.nordstrom.kafka.connect.utils;
+
+import org.apache.kafka.common.errors.RetriableException;
+
+public class ParseException extends RetriableException {
+    public ParseException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}


### PR DESCRIPTION
When `value.transform.to.json` is enabled, a parsing error will throw an exception and stop the connector so messages are not lost.