### PR TITLE
[EFEKTA-8835] - Enable `value.converter` for JSON data

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Optional properties:
 * `sqs.message.attributes.enabled`: If true, it gets the SQS MessageAttributes and inserts them as Kafka Headers (only string headers are currently supported). Default is false.
 * `sqs.message.attributes.include.list`: The comma separated list of MessageAttribute names to be included, if empty it includes all the Message Attributes. Default is the empty string.
 * `sqs.message.attributes.partition.key`: The name of a single AWS SQS MessageAttribute to use as the partition key. If this is not specified, default to the SQS message ID as the partition key.
+* `value.transform.to.json`: If true, it expects to receive a valid JSON as string, and it will be converted to a proper `Struct` in Kafka Connect. Default is false. This is useful when the `value.converter` is set to ProtobufConverter or any other non-JSON or String converter as the converter will be able to convert the data.
 
 ### Sample IAM policy
 

--- a/src/main/java/com/nordstrom/kafka/connect/sqs/SqsConnectorConfig.java
+++ b/src/main/java/com/nordstrom/kafka/connect/sqs/SqsConnectorConfig.java
@@ -5,9 +5,6 @@ import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigException;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 
 abstract public class SqsConnectorConfig extends AbstractConfig {
@@ -15,8 +12,6 @@ abstract public class SqsConnectorConfig extends AbstractConfig {
     private final String topics;
     private final String region;
     private final String endpointUrl;
-    private final Boolean transformToJson;
-    private final String timestampFormat;
 
     public SqsConnectorConfig(ConfigDef configDef, Map<?, ?> originals) {
         super(configDef, originals);
@@ -24,8 +19,6 @@ abstract public class SqsConnectorConfig extends AbstractConfig {
         topics = getString(SqsConnectorConfigKeys.TOPICS.getValue());
         region = getString(SqsConnectorConfigKeys.SQS_REGION.getValue());
         endpointUrl = getString(SqsConnectorConfigKeys.SQS_ENDPOINT_URL.getValue());
-        transformToJson = getBoolean(SqsConnectorConfigKeys.VALUE_TRANSFORM_TO_JSON.getValue());
-        timestampFormat = getString(SqsConnectorConfigKeys.VALUE_TRANSFORM_TIMESTAMP_FORMAT.getValue());
     }
 
     public String getQueueUrl() {
@@ -43,10 +36,6 @@ abstract public class SqsConnectorConfig extends AbstractConfig {
     public String getEndpointUrl()  {
         return endpointUrl;
     }
-
-    public Boolean getTransformToJson() { return transformToJson; }
-
-    public String getTimestampFormat() { return timestampFormat; }
 
     protected static class CredentialsProviderValidator implements ConfigDef.Validator {
         @Override

--- a/src/main/java/com/nordstrom/kafka/connect/sqs/SqsConnectorConfig.java
+++ b/src/main/java/com/nordstrom/kafka/connect/sqs/SqsConnectorConfig.java
@@ -12,6 +12,7 @@ abstract public class SqsConnectorConfig extends AbstractConfig {
     private final String topics;
     private final String region;
     private final String endpointUrl;
+    private final Boolean transformToJson;
 
     public SqsConnectorConfig(ConfigDef configDef, Map<?, ?> originals) {
         super(configDef, originals);
@@ -19,6 +20,7 @@ abstract public class SqsConnectorConfig extends AbstractConfig {
         topics = getString(SqsConnectorConfigKeys.TOPICS.getValue());
         region = getString(SqsConnectorConfigKeys.SQS_REGION.getValue());
         endpointUrl = getString(SqsConnectorConfigKeys.SQS_ENDPOINT_URL.getValue());
+        transformToJson = getBoolean(SqsConnectorConfigKeys.VALUE_TRANSFORM_TO_JSON.getValue());
     }
 
     public String getQueueUrl() {
@@ -36,6 +38,8 @@ abstract public class SqsConnectorConfig extends AbstractConfig {
     public String getEndpointUrl()  {
         return endpointUrl;
     }
+
+    public Boolean getTransformToJson() { return transformToJson; }
 
     protected static class CredentialsProviderValidator implements ConfigDef.Validator {
         @Override

--- a/src/main/java/com/nordstrom/kafka/connect/sqs/SqsSinkConnectorConfig.java
+++ b/src/main/java/com/nordstrom/kafka/connect/sqs/SqsSinkConnectorConfig.java
@@ -20,17 +20,15 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import com.amazonaws.auth.AWSCredentialsProvider;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Importance;
 import org.apache.kafka.common.config.ConfigDef.Type;
-import org.apache.kafka.common.config.ConfigException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class SqsSinkConnectorConfig extends SqsConnectorConfig {
   private final Boolean messageAttributesEnabled;
   private final List<String> messageAttributesList;
+  private final Boolean transformToJson;
+  private final String timestampFormat;
 
   private static final ConfigDef CONFIG_DEF = new ConfigDef()
       .define(SqsConnectorConfigKeys.SQS_QUEUE_URL.getValue(), Type.STRING, Importance.HIGH, "URL of the SQS queue to be written to.")
@@ -68,6 +66,9 @@ public class SqsSinkConnectorConfig extends SqsConnectorConfig {
   public SqsSinkConnectorConfig(Map<?, ?> originals) {
     super(config(), originals);
 
+    transformToJson = getBoolean(SqsConnectorConfigKeys.VALUE_TRANSFORM_TO_JSON.getValue());
+    timestampFormat = getString(SqsConnectorConfigKeys.VALUE_TRANSFORM_TIMESTAMP_FORMAT.getValue());
+
     messageAttributesEnabled = getBoolean(SqsConnectorConfigKeys.SQS_MESSAGE_ATTRIBUTES_ENABLED.getValue());
     if (messageAttributesEnabled) {
       messageAttributesList = getList(SqsConnectorConfigKeys.SQS_MESSAGE_ATTRIBUTES_INCLUDE_LIST.getValue());
@@ -83,5 +84,9 @@ public class SqsSinkConnectorConfig extends SqsConnectorConfig {
   public List<String> getMessageAttributesList() {
     return messageAttributesList;
   }
+
+  public Boolean getTransformToJson() { return transformToJson; }
+
+  public String getTimestampFormat() { return timestampFormat; }
 
 }

--- a/src/main/java/com/nordstrom/kafka/connect/sqs/SqsSinkConnectorConfig.java
+++ b/src/main/java/com/nordstrom/kafka/connect/sqs/SqsSinkConnectorConfig.java
@@ -27,7 +27,7 @@ import org.apache.kafka.common.config.ConfigDef.Type;
 public class SqsSinkConnectorConfig extends SqsConnectorConfig {
   private final Boolean messageAttributesEnabled;
   private final List<String> messageAttributesList;
-  private final Boolean transformToJson;
+
   private final String timestampFormat;
 
   private static final ConfigDef CONFIG_DEF = new ConfigDef()
@@ -65,8 +65,6 @@ public class SqsSinkConnectorConfig extends SqsConnectorConfig {
 
   public SqsSinkConnectorConfig(Map<?, ?> originals) {
     super(config(), originals);
-
-    transformToJson = getBoolean(SqsConnectorConfigKeys.VALUE_TRANSFORM_TO_JSON.getValue());
     timestampFormat = getString(SqsConnectorConfigKeys.VALUE_TRANSFORM_TIMESTAMP_FORMAT.getValue());
 
     messageAttributesEnabled = getBoolean(SqsConnectorConfigKeys.SQS_MESSAGE_ATTRIBUTES_ENABLED.getValue());
@@ -84,8 +82,6 @@ public class SqsSinkConnectorConfig extends SqsConnectorConfig {
   public List<String> getMessageAttributesList() {
     return messageAttributesList;
   }
-
-  public Boolean getTransformToJson() { return transformToJson; }
 
   public String getTimestampFormat() { return timestampFormat; }
 

--- a/src/main/java/com/nordstrom/kafka/connect/sqs/SqsSourceConnectorConfig.java
+++ b/src/main/java/com/nordstrom/kafka/connect/sqs/SqsSourceConnectorConfig.java
@@ -58,7 +58,9 @@ public class SqsSourceConnectorConfig extends SqsConnectorConfig {
       .define(SqsConnectorConfigKeys.SQS_MESSAGE_ATTRIBUTES_INCLUDE_LIST.getValue(), Type.LIST, "", Importance.LOW,
           "The comma separated list of MessageAttribute names to be included, if empty it includes all the Message Attributes. Default is the empty string.")
       .define(SqsConnectorConfigKeys.SQS_MESSAGE_ATTRIBUTE_PARTITION_KEY.getValue(), Type.STRING, "", Importance.LOW,
-          "The name of a single AWS SQS MessageAttribute to use as the partition key");
+          "The name of a single AWS SQS MessageAttribute to use as the partition key")
+      .define(SqsConnectorConfigKeys.VALUE_TRANSFORM_TO_JSON.getValue(), Type.BOOLEAN, false, Importance.LOW,
+          "If true, it expects SQS messages to be valid JSON and it will parse them to proper Structs. Protobuf, Avro or other value converters can be used when this is set to true. Default is false.");
 
   public static ConfigDef config() {
     return CONFIG_DEF;

--- a/src/main/java/com/nordstrom/kafka/connect/sqs/SqsSourceConnectorTask.java
+++ b/src/main/java/com/nordstrom/kafka/connect/sqs/SqsSourceConnectorTask.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2019 Nordstrom, Inc.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
@@ -14,170 +14,265 @@
  * the License.
  */
 
-package com.nordstrom.kafka.connect.sqs ;
+package com.nordstrom.kafka.connect.sqs;
 
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.*;
-import java.util.stream.Collectors ;
+import java.util.stream.Collectors;
 
 import com.amazonaws.services.sqs.model.MessageAttributeValue;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nordstrom.kafka.connect.utils.ParseException;
 import com.nordstrom.kafka.connect.utils.StringUtils;
-import org.apache.kafka.connect.data.Schema ;
-import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.data.*;
 import org.apache.kafka.connect.header.ConnectHeaders;
-import org.apache.kafka.connect.source.SourceRecord ;
-import org.apache.kafka.connect.source.SourceTask ;
-import org.slf4j.Logger ;
-import org.slf4j.LoggerFactory ;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.apache.kafka.connect.source.SourceTask;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import com.amazonaws.services.sqs.model.Message ;
-import com.nordstrom.kafka.connect.About ;
+import com.amazonaws.services.sqs.model.Message;
+import com.nordstrom.kafka.connect.About;
 
 public class SqsSourceConnectorTask extends SourceTask {
-  private final Logger log = LoggerFactory.getLogger( this.getClass() ) ;
+    private final Logger log = LoggerFactory.getLogger(this.getClass());
 
-  private SqsClient client ;
-  private SqsSourceConnectorConfig config ;
+    private SqsClient client;
+    private SqsSourceConnectorConfig config;
 
-  /*
-   * (non-Javadoc)
-   * 
-   * @see org.apache.kafka.connect.connector.Task#version()
-   */
-  @Override
-  public String version() {
-    return About.CURRENT_VERSION ;
-  }
-
-  /*
-   * (non-Javadoc)
-   * 
-   * @see org.apache.kafka.connect.source.SourceTask#start(java.util.Map)
-   */
-  @Override
-  public void start( Map<String, String> props ) {
-    log.info( "task.start" ) ;
-    Guard.verifyNotNull( props, "Task properties" ) ;
-
-    config = new SqsSourceConnectorConfig( props ) ;
-    client = new SqsClient(config) ;
-
-    log.info( "task.start.OK, sqs.queue.url={}, topics={}", config.getQueueUrl(), config.getTopics() ) ;
-  }
-
-  private String getPartitionKey(Message message) {
-    String messageId = message.getMessageId();
-    if (!config.getMessageAttributesEnabled()) {
-      return messageId;
-    }
-    String messageAttributePartitionKey = config.getMessageAttributePartitionKey();
-    if (StringUtils.isBlank(messageAttributePartitionKey)) {
-      return messageId;
+    /*
+     * (non-Javadoc)
+     *
+     * @see org.apache.kafka.connect.connector.Task#version()
+     */
+    @Override
+    public String version() {
+        return About.CURRENT_VERSION;
     }
 
-    // search for the String message attribute with the same name as the configured partition key
-    Map<String, MessageAttributeValue> attributes = message.getMessageAttributes();
-    for(String attributeKey: attributes.keySet()) {
-      if (!Objects.equals(attributeKey, messageAttributePartitionKey)) {
-        continue;
-      }
-      MessageAttributeValue attrValue = attributes.get(attributeKey);
-      if (!attrValue.getDataType().equals("String")) {
-        continue;
-      }
-      return attrValue.getStringValue();
-    }
-    return messageId;
-  }
+    /*
+     * (non-Javadoc)
+     *
+     * @see org.apache.kafka.connect.source.SourceTask#start(java.util.Map)
+     */
+    @Override
+    public void start(Map<String, String> props) {
+        log.info("task.start");
+        Guard.verifyNotNull(props, "Task properties");
 
-  /*
-   * (non-Javadoc)
-   * 
-   * @see org.apache.kafka.connect.source.SourceTask#poll()
-   */
-  @Override
-  public List<SourceRecord> poll() throws InterruptedException {
-    log.debug( ".poll:valid-state={}", isValidState() ) ;
+        config = new SqsSourceConnectorConfig(props);
+        client = new SqsClient(config);
 
-    if ( !isValidState() ) {
-      throw new IllegalStateException( "Task is not properly initialized" ) ;
+        log.info("task.start.OK, sqs.queue.url={}, topics={}", config.getQueueUrl(), config.getTopics());
     }
 
-    // Read messages from the queue.
-    List<Message> messages = client.receive(
-        config.getQueueUrl(),
-        config.getMaxMessages(),
-        config.getWaitTimeSeconds(),
-        config.getMessageAttributesEnabled(),
-        config.getMessageAttributesList());
-    log.debug( ".poll:url={}, max={}, wait={}, size={}", config.getQueueUrl(), config.getMaxMessages(),
-        config.getWaitTimeSeconds(), messages.size() ) ;
-
-    // Create a SourceRecord for each message in the queue.
-    return messages.stream().map( message -> {
-
-      Map<String, String> sourcePartition = Collections.singletonMap( SqsConnectorConfigKeys.SQS_QUEUE_URL.getValue(),
-          config.getQueueUrl() ) ;
-      Map<String, String> sourceOffset = new HashMap<>() ;
-      // Save the message id and receipt-handle. receipt-handle is needed to delete
-      // the message once the record is committed.
-      sourceOffset.put( SqsConnectorConfigKeys.SQS_MESSAGE_ID.getValue(), message.getMessageId() ) ;
-      sourceOffset.put( SqsConnectorConfigKeys.SQS_MESSAGE_RECEIPT_HANDLE.getValue(), message.getReceiptHandle() ) ;
-      log.trace( ".poll:source-partition={}", sourcePartition ) ;
-      log.trace( ".poll:source-offset={}", sourceOffset ) ;
-
-      final String body = message.getBody();
-      final String key = getPartitionKey(message);
-      final String topic = config.getTopics() ;
-
-      final ConnectHeaders headers = new ConnectHeaders();
-      if (config.getMessageAttributesEnabled()) {
-        Map<String, MessageAttributeValue> attributes = message.getMessageAttributes();
-        // sqs api should return only the fields specified in the list
-        for(String attributeKey: attributes.keySet()) {
-          MessageAttributeValue attrValue = attributes.get(attributeKey);
-          if (attrValue.getDataType().equals("String")) {
-            SchemaAndValue schemaAndValue = new SchemaAndValue(Schema.STRING_SCHEMA, attrValue.getStringValue());
-            headers.add(attributeKey, schemaAndValue);
-          }
+    private String getPartitionKey(Message message) {
+        String messageId = message.getMessageId();
+        if (!config.getMessageAttributesEnabled()) {
+            return messageId;
         }
-      }
+        String messageAttributePartitionKey = config.getMessageAttributePartitionKey();
+        if (StringUtils.isBlank(messageAttributePartitionKey)) {
+            return messageId;
+        }
 
-      return new SourceRecord(sourcePartition, sourceOffset, topic, null, Schema.STRING_SCHEMA, key, Schema.STRING_SCHEMA,
-          body, null, headers) ;
-    } ).collect( Collectors.toList() ) ;
-  }
+        // search for the String message attribute with the same name as the configured partition key
+        Map<String, MessageAttributeValue> attributes = message.getMessageAttributes();
+        for (String attributeKey : attributes.keySet()) {
+            if (!Objects.equals(attributeKey, messageAttributePartitionKey)) {
+                continue;
+            }
+            MessageAttributeValue attrValue = attributes.get(attributeKey);
+            if (!attrValue.getDataType().equals("String")) {
+                continue;
+            }
+            return attrValue.getStringValue();
+        }
+        return messageId;
+    }
 
-  /* (non-Javadoc)
-   * @see org.apache.kafka.connect.source.SourceTask#commitRecord(org.apache.kafka.connect.source.SourceRecord)
-   */
-  @Override
-  public void commitRecord( SourceRecord record ) throws InterruptedException {
-    Guard.verifyNotNull( record, "record" ) ;
-    final String receipt = record.sourceOffset().get( SqsConnectorConfigKeys.SQS_MESSAGE_RECEIPT_HANDLE.getValue() )
-        .toString() ;
-    log.debug( ".commit-record:url={}, receipt-handle={}", config.getQueueUrl(), receipt ) ;
-    client.delete( config.getQueueUrl(), receipt ) ;
-    super.commitRecord( record ) ;
-  }
+    /*
+     * (non-Javadoc)
+     *
+     * @see org.apache.kafka.connect.source.SourceTask#poll()
+     */
+    @Override
+    public List<SourceRecord> poll() throws InterruptedException {
+        log.debug(".poll:valid-state={}", isValidState());
 
-  /*
-   * (non-Javadoc)
-   * 
-   * @see org.apache.kafka.connect.source.SourceTask#stop()
-   */
-  @Override
-  public void stop() {
-    log.info( "task.stop:OK" ) ;
-  }
+        if (!isValidState()) {
+            throw new IllegalStateException("Task is not properly initialized");
+        }
 
-  /**
-   * Test that we have both the task configuration and SQS client properly
-   * initialized.
-   * 
-   * @return true if task is in a valid state.
-   */
-  private boolean isValidState() {
-    return null != config && null != client ;
-  }
+        // Read messages from the queue.
+        List<Message> messages = client.receive(
+                config.getQueueUrl(),
+                config.getMaxMessages(),
+                config.getWaitTimeSeconds(),
+                config.getMessageAttributesEnabled(),
+                config.getMessageAttributesList());
+        log.debug(".poll:url={}, max={}, wait={}, size={}", config.getQueueUrl(), config.getMaxMessages(),
+                config.getWaitTimeSeconds(), messages.size());
+
+        // Create a SourceRecord for each message in the queue.
+        return messages.stream().map(message -> {
+
+            Map<String, String> sourcePartition = Collections.singletonMap(SqsConnectorConfigKeys.SQS_QUEUE_URL.getValue(),
+                    config.getQueueUrl());
+            Map<String, String> sourceOffset = new HashMap<>();
+            // Save the message id and receipt-handle. receipt-handle is needed to delete
+            // the message once the record is committed.
+            sourceOffset.put(SqsConnectorConfigKeys.SQS_MESSAGE_ID.getValue(), message.getMessageId());
+            sourceOffset.put(SqsConnectorConfigKeys.SQS_MESSAGE_RECEIPT_HANDLE.getValue(), message.getReceiptHandle());
+            log.trace(".poll:source-partition={}", sourcePartition);
+            log.trace(".poll:source-offset={}", sourceOffset);
+
+            final String body = message.getBody();
+            final String key = getPartitionKey(message);
+            final String topic = config.getTopics();
+
+            final ConnectHeaders headers = new ConnectHeaders();
+            if (config.getMessageAttributesEnabled()) {
+                Map<String, MessageAttributeValue> attributes = message.getMessageAttributes();
+                // sqs api should return only the fields specified in the list
+                for (String attributeKey : attributes.keySet()) {
+                    MessageAttributeValue attrValue = attributes.get(attributeKey);
+                    if (attrValue.getDataType().equals("String")) {
+                        SchemaAndValue schemaAndValue = new SchemaAndValue(Schema.STRING_SCHEMA, attrValue.getStringValue());
+                        headers.add(attributeKey, schemaAndValue);
+                    }
+                }
+            }
+
+            return parseJSON(body, sourcePartition, sourceOffset, topic, key, headers);
+        }).collect(Collectors.toList());
+    }
+
+    static SourceRecord parseJSON(String body, Map<String, String> sourcePartition, Map<String, String> sourceOffset, String topic, String key, ConnectHeaders headers) {
+        // Parse JSON string to Map
+        ObjectMapper objectMapper = new ObjectMapper();
+        Map<String, Object> jsonMap;
+        try {
+            jsonMap = objectMapper.readValue(body, new TypeReference<Map<String, Object>>() {
+            });
+        } catch (JsonProcessingException e) {
+            throw new ParseException("Failed to parse JSON from SQS", e);
+        }
+
+        // Build Schema from Map
+        SchemaBuilder schemaBuilder = SchemaBuilder.struct();
+        jsonMap.forEach((k, v) -> {
+            if (v instanceof Integer) {
+                schemaBuilder.field(k, Schema.OPTIONAL_INT32_SCHEMA);
+            } else if (v instanceof Long) {
+                schemaBuilder.field(k, Schema.OPTIONAL_INT64_SCHEMA);
+            } else if (v instanceof Float) {
+                schemaBuilder.field(k, Schema.OPTIONAL_FLOAT32_SCHEMA);
+            } else if (v instanceof Double) {
+                schemaBuilder.field(k, Schema.OPTIONAL_FLOAT64_SCHEMA);
+            } else if (v instanceof Boolean) {
+                schemaBuilder.field(k, Schema.OPTIONAL_BOOLEAN_SCHEMA);
+            } else if (v instanceof String) {
+                Optional<java.sql.Timestamp> timestamp = parseTimestamp((String) v);
+                if (timestamp.isPresent()) {
+                    schemaBuilder.field(k, Timestamp.SCHEMA);
+                } else {
+                    schemaBuilder.field(k, Schema.OPTIONAL_STRING_SCHEMA);
+                }
+            } else {
+                schemaBuilder.field(k, Schema.OPTIONAL_STRING_SCHEMA);
+            }
+        });
+
+        Schema schema = schemaBuilder.build();
+        Struct struct = new Struct(schema);
+
+        // Populate Struct from Map
+        // Custom types need to be converted to the appropriate type
+        jsonMap.forEach((k, v) -> {
+            if (v instanceof String) {
+                Optional<java.sql.Timestamp> timestamp = parseTimestamp((String) v);
+                if (timestamp.isPresent()) {
+                    struct.put(k, timestamp.get());
+                } else {
+                    struct.put(k, v);
+                }
+            } else {
+                struct.put(k, v);
+            }
+        });
+
+        return new SourceRecord(sourcePartition, sourceOffset, topic, null, Schema.STRING_SCHEMA, key, schema, struct, null, headers);
+    }
+
+    /**
+     * Given a String, tries to convert it to one of the defined timestamp formats.
+     *
+     * @param value String to be parsed.
+     * @return Optional of java.sql.Timestamp if the value could be parsed, empty otherwise.
+     */
+    private static Optional<java.sql.Timestamp> parseTimestamp(String value) {
+        // List of supported date-time formatters
+        DateTimeFormatter[] formatters = new DateTimeFormatter[]{
+                DateTimeFormatter.ISO_INSTANT,
+                DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").withZone(ZoneId.of("UTC"))
+        };
+
+        for (DateTimeFormatter formatter : formatters) {
+            try {
+                Instant instant;
+                if (formatter == DateTimeFormatter.ISO_INSTANT) {
+                    instant = Instant.parse(value);
+                } else {
+                    LocalDateTime localDateTime = LocalDateTime.parse(value, formatter);
+                    instant = localDateTime.atZone(ZoneId.of("UTC")).toInstant();
+                }
+                return Optional.of(java.sql.Timestamp.from(instant));
+            } catch (DateTimeParseException e) {
+                // Continue to the next formatter
+            }
+        }
+        return Optional.empty();
+    }
+
+
+    /* (non-Javadoc)
+     * @see org.apache.kafka.connect.source.SourceTask#commitRecord(org.apache.kafka.connect.source.SourceRecord)
+     */
+    @Override
+    public void commitRecord(SourceRecord record) throws InterruptedException {
+        Guard.verifyNotNull(record, "record");
+        final String receipt = record.sourceOffset().get(SqsConnectorConfigKeys.SQS_MESSAGE_RECEIPT_HANDLE.getValue())
+                .toString();
+        log.debug(".commit-record:url={}, receipt-handle={}", config.getQueueUrl(), receipt);
+        client.delete(config.getQueueUrl(), receipt);
+        super.commitRecord(record);
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see org.apache.kafka.connect.source.SourceTask#stop()
+     */
+    @Override
+    public void stop() {
+        log.info("task.stop:OK");
+    }
+
+    /**
+     * Test that we have both the task configuration and SQS client properly
+     * initialized.
+     *
+     * @return true if task is in a valid state.
+     */
+    private boolean isValidState() {
+        return null != config && null != client;
+    }
 
 }

--- a/src/main/java/com/nordstrom/kafka/connect/utils/KafkaJsonToStruct.java
+++ b/src/main/java/com/nordstrom/kafka/connect/utils/KafkaJsonToStruct.java
@@ -1,0 +1,104 @@
+package com.nordstrom.kafka.connect.utils;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.data.Timestamp;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.Map;
+import java.util.Optional;
+
+public class KafkaJsonToStruct {
+
+    public static SchemaBuilder buildSchema(Map<String, Object> jsonMap) {
+        SchemaBuilder schemaBuilder = SchemaBuilder.struct();
+        jsonMap.forEach((k, v) -> {
+            if (v instanceof Map) {
+                // Nested JSON object detected
+                //noinspection unchecked
+                SchemaBuilder nestedSchema = buildSchema((Map<String, Object>) v);
+                schemaBuilder.field(k, nestedSchema.build());
+            } else if (v instanceof Integer) {
+                schemaBuilder.field(k, Schema.OPTIONAL_INT32_SCHEMA);
+            } else if (v instanceof Long) {
+                schemaBuilder.field(k, Schema.OPTIONAL_INT64_SCHEMA);
+            } else if (v instanceof Float) {
+                schemaBuilder.field(k, Schema.OPTIONAL_FLOAT32_SCHEMA);
+            } else if (v instanceof Double) {
+                schemaBuilder.field(k, Schema.OPTIONAL_FLOAT64_SCHEMA);
+            } else if (v instanceof Boolean) {
+                schemaBuilder.field(k, Schema.OPTIONAL_BOOLEAN_SCHEMA);
+            } else if (v instanceof String) {
+                Optional<java.sql.Timestamp> timestamp = parseTimestamp((String) v);
+                if (timestamp.isPresent()) {
+                    schemaBuilder.field(k, Timestamp.SCHEMA);
+                } else {
+                    schemaBuilder.field(k, Schema.OPTIONAL_STRING_SCHEMA);
+                }
+            } else {
+                schemaBuilder.field(k, Schema.OPTIONAL_STRING_SCHEMA);
+            }
+        });
+        return schemaBuilder;
+    }
+
+    public static Struct buildStruct(Map<String, Object> jsonMap, Schema schema) {
+        Struct struct = new Struct(schema);
+        jsonMap.forEach((k, v) -> {
+            Schema fieldSchema = schema.field(k).schema();
+            if (v instanceof Map) {
+                // Recursive call for nested object.
+                Struct nestedStruct = buildStruct((Map<String, Object>) v, fieldSchema);
+                struct.put(k, nestedStruct);
+            } else if (v instanceof String) {
+                // Parse timestamps if possible.
+                Optional<java.sql.Timestamp> timestamp = parseTimestamp((String) v);
+                if (timestamp.isPresent()) {
+                    struct.put(k, timestamp.get());
+                } else {
+                    struct.put(k, v);
+                }
+            } else {
+                // basic types
+                struct.put(k, v);
+            }
+        });
+        return struct;
+    }
+
+    /**
+     * Given a String, tries to convert it to one of the defined timestamp formats.
+     *
+     * @param value String to be parsed.
+     * @return Optional of java.sql.Timestamp if the value could be parsed, empty otherwise.
+     */
+    public static Optional<java.sql.Timestamp> parseTimestamp(String value) {
+        // List of supported date-time formatters
+        DateTimeFormatter[] formatters = new DateTimeFormatter[]{
+                DateTimeFormatter.ISO_INSTANT,
+                DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").withZone(ZoneId.of("UTC"))
+        };
+
+        for (DateTimeFormatter formatter : formatters) {
+            try {
+                Instant instant;
+                if (formatter == DateTimeFormatter.ISO_INSTANT) {
+                    instant = Instant.parse(value);
+                } else {
+                    LocalDateTime localDateTime = LocalDateTime.parse(value, formatter);
+                    instant = localDateTime.atZone(ZoneId.of("UTC")).toInstant();
+                }
+                return Optional.of(java.sql.Timestamp.from(instant));
+            } catch (DateTimeParseException e) {
+                // Not throwing, only returning empty if no formatter could parse the value
+            }
+        }
+        return Optional.empty();
+    }
+
+}

--- a/src/main/test/com/nordstrom/kafka/connect/sqs/SqsSourceConnectorTaskTest.java
+++ b/src/main/test/com/nordstrom/kafka/connect/sqs/SqsSourceConnectorTaskTest.java
@@ -1,0 +1,90 @@
+package com.nordstrom.kafka.connect.sqs;
+
+import com.nordstrom.kafka.connect.utils.ParseException;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.header.ConnectHeaders;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.Map;
+import static org.junit.jupiter.api.Assertions.*;
+
+class SqsSourceConnectorTaskTest {
+
+    Map<String, String> sourcePartition = Collections.singletonMap("partitionKey", "partitionValue");
+    Map<String, String> sourceOffset = Collections.singletonMap("offsetKey", "offsetValue");
+    String topic = "testTopic";
+    String key = "testKey";
+    ConnectHeaders headers = new ConnectHeaders();
+
+    @Test
+    void parseJSONString() {
+        String body = "{\"field1\":\"value1\",\"field2\":\"test\"}";
+        SourceRecord result = SqsSourceConnectorTask.parseJSON(body, sourcePartition, sourceOffset, topic, key, headers);
+
+        Struct value = (Struct) result.value();
+        assertEquals("value1", value.getString("field1"));
+        assertEquals("test", value.getString("field2"));
+    }
+    
+    @Test
+    void parseJSONInteger() {
+        String body = "{\"field1\":\"value1\",\"field2\":2}";
+        SourceRecord result = SqsSourceConnectorTask.parseJSON(body, sourcePartition, sourceOffset, topic, key, headers);
+
+        Struct value = (Struct) result.value();
+        assertEquals("value1", value.getString("field1"));
+        assertEquals(2, value.getInt32("field2"));
+    }
+
+    @Test
+    void parseJSONFloat() {
+        String body = "{\"field1\":\"value1\",\"field2\":2.3}";
+        SourceRecord result = SqsSourceConnectorTask.parseJSON(body, sourcePartition, sourceOffset, topic, key, headers);
+
+        Struct value = (Struct) result.value();
+        assertEquals("value1", value.getString("field1"));
+        assertEquals(2.3, value.getFloat64("field2"));
+    }
+
+    @Test
+    void parseJSONDateTimeISO8601() {
+        String body = "{\"field1\":\"value1\",\"field2\":\"2023-10-01T10:20:30Z\"}";
+        SourceRecord result = SqsSourceConnectorTask.parseJSON(body, sourcePartition, sourceOffset, topic, key, headers);
+
+        Struct value = (Struct) result.value();
+        assertEquals("value1", value.getString("field1"));
+        assertEquals(Timestamp.from(Instant.parse("2023-10-01T10:20:30Z")), value.get("field2"));
+    }
+
+    @Test
+    void parseJSONDateTime() {
+        String body = "{\"field1\":\"value1\",\"field2\":\"2023-10-01 10:20:30\"}";
+        SourceRecord result = SqsSourceConnectorTask.parseJSON(body, sourcePartition, sourceOffset, topic, key, headers);
+
+        Struct value = (Struct) result.value();
+        assertEquals("value1", value.getString("field1"));
+        assertEquals(Timestamp.from(Instant.parse("2023-10-01T10:20:30Z")), value.get("field2"));
+    }
+
+    @Test
+    void parseJSONEmptyJson() {
+        String body = "{}";
+        SourceRecord result = SqsSourceConnectorTask.parseJSON(body, sourcePartition, sourceOffset, topic, key, headers);
+
+        assertNotNull(result);
+        Struct value = (Struct) result.value();
+        assertTrue(value.schema().fields().isEmpty());
+    }
+
+    @Test
+    void parseJSONInvalidJson() {
+        String body = "{invalidJson}";
+        assertThrows(ParseException.class, () -> {
+            SqsSourceConnectorTask.parseJSON(body, sourcePartition, sourceOffset, topic, key, headers);
+        });
+    }
+}


### PR DESCRIPTION
The current Source connector receives data as String from an SQS and sends that data to Kafka. `value.converter` can not be set to anything other than `String` as the resulting object from the Source connector is a plain String.

This change includes a JSON parsing process that transforms a JSON received from SQS into a proper `Struct` object in Kafka Connect. Once the data is in the `Struct` type, `value.converter` can be used to transform the data into Protobuf, Avro or any other.

This is also automatically parsing String datetimes into `Timestamps`.

Numeric Timestamps coming from JSON are not automatically transformed into `Timestamp` as there is no difference between them and a regular numeric value. [SMT transformations](https://docs.confluent.io/kafka-connectors/transforms/current/timestampconverter.html) need to be used if that kind of transformation is desired.

`value.transform.to.json` set to `true` will enable these transformations.