### PR TITLE
Fix Timestamp parsing.

### DIFF
--- a/src/main/java/com/nordstrom/kafka/connect/utils/StructSerializer.java
+++ b/src/main/java/com/nordstrom/kafka/connect/utils/StructSerializer.java
@@ -3,11 +3,14 @@ package com.nordstrom.kafka.connect.utils;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
+import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.data.Timestamp;
 
 import java.io.IOException;
 import java.text.SimpleDateFormat;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 public class StructSerializer extends JsonSerializer<Struct> {
 
@@ -20,20 +23,19 @@ public class StructSerializer extends JsonSerializer<Struct> {
     }
 
     @Override
-    public void serialize(Struct struct, JsonGenerator gen, SerializerProvider serializers) throws IOException {
-        gen.writeStartObject();
-        struct.schema().fields().forEach(field -> {
-            try {
-                Object value = struct.get(field);
-                // Transform timestamp to defined format
-                if (timestampPattern != null && field.schema().name() != null && field.schema().name().equals(Timestamp.LOGICAL_NAME)) {
-                    value = dateFormat.format(value);
+    public void serialize(Struct struct, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException {
+        final Map<String, Object> result = new LinkedHashMap<>(struct.schema().fields().size());
+        for (Field field : struct.schema().fields()) {
+            Object value = struct.get(field);
+            // Transform timestamp to defined format
+            if (timestampPattern != null && field.schema().name() != null && field.schema().name().equals(Timestamp.LOGICAL_NAME)) {
+                // Protobuf optional timestamps might have a null value
+                if (value instanceof java.util.Date) {
+                    value = dateFormat.format((java.util.Date) value);
                 }
-                gen.writeObjectField(field.name(), value);
-            } catch (IOException e) {
-                throw new RuntimeException(e);
             }
-        });
-        gen.writeEndObject();
+            result.put(field.name(), value);
+        }
+        jsonGenerator.writeObject(result);
     }
 }

--- a/src/main/test/com/nordstrom/kafka/connect/sqs/SqsSinkConnectorTaskTest.java
+++ b/src/main/test/com/nordstrom/kafka/connect/sqs/SqsSinkConnectorTaskTest.java
@@ -105,6 +105,51 @@ public class SqsSinkConnectorTaskTest {
     }
 
     @Test
+    public void testPutWithNestedStructAndArraysValue() throws Exception {
+        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm");
+        Date date = dateFormat.parse("2025-01-01 01:20");
+
+        Schema nestedSchema = SchemaBuilder.struct()
+                .field("nestedField1", Schema.STRING_SCHEMA)
+                .field("nestedField2", Schema.INT32_SCHEMA)
+                .field("timestampField", Timestamp.SCHEMA)
+                .build();
+
+        Struct nestedStruct1 = new Struct(nestedSchema)
+                .put("nestedField1", "nestedTest1")
+                .put("nestedField2", 456)
+                .put("timestampField", date);
+
+        Struct nestedStruct2 = new Struct(nestedSchema)
+                .put("nestedField1", "nestedTest2")
+                .put("nestedField2", 789)
+                .put("timestampField", date);
+
+        Schema mainSchema = SchemaBuilder.struct()
+                .field("field1", Schema.STRING_SCHEMA)
+                .field("field2", Schema.INT32_SCHEMA)
+                .field("nestedArray", SchemaBuilder.array(nestedSchema).build())
+                .build();
+
+        Struct mainStruct = new Struct(mainSchema)
+                .put("field1", "test")
+                .put("field2", 123)
+                .put("nestedArray", Arrays.asList(nestedStruct1, nestedStruct2));
+
+
+        SinkRecord record = new SinkRecord("topic", 0, Schema.STRING_SCHEMA, "key", mainSchema, mainStruct, 0);
+        Collection<SinkRecord> records = Collections.singletonList(record);
+
+        task.put(records);
+
+        ArgumentCaptor<String> bodyCaptor = ArgumentCaptor.forClass(String.class);
+        verify(mockClient).send(anyString(), bodyCaptor.capture(), anyString(), anyString(), any());
+        String body = bodyCaptor.getValue();
+        System.out.println(body);
+        assertEquals("{\"field1\":\"test\",\"field2\":123,\"nestedArray\":[{\"nestedField1\":\"nestedTest1\",\"nestedField2\":456,\"timestampField\":\"2025-01-01T01:20:00Z\"},{\"nestedField1\":\"nestedTest2\",\"nestedField2\":789,\"timestampField\":\"2025-01-01T01:20:00Z\"}]}", body);
+    }
+
+    @Test
     public void testPutWithTimestampyyyyMMdd() throws Exception {
         task.objectMapper = ObjectMapperProvider.getObjectMapper("yyyy-MM-dd HH:mm:ss");
         Schema schema = SchemaBuilder.struct()


### PR DESCRIPTION
When a Timestamp comes from an optional Protobuf field, Kafka Connect keeps a null value. This PR should skip the timestamp transformation on those cases.